### PR TITLE
Optimise Dockerfile image security and size

### DIFF
--- a/Dockerfile.public
+++ b/Dockerfile.public
@@ -1,13 +1,20 @@
-FROM golang:1.18
+FROM golang:1.18-alpine3.15 AS build-stage
+
+WORKDIR /usr/src/app
+
+COPY . .
+RUN go build -v -o ./bin/server
+
+
+FROM alpine:3.15.4
 
 EXPOSE 3000
 WORKDIR /usr/src/app
 
-# pre-copy/cache go.mod for pre-downloading dependencies and only redownloading them in subsequent builds if they change
-COPY go.mod go.sum ./
-RUN go mod download && go mod verify
+COPY --from=build-stage /usr/src/app/bin/server /usr/src/app/
+COPY ./data ./data
 
-COPY . .
-RUN go build -v -o /usr/local/bin/server
+RUN adduser -D appuser
+USER appuser
 
-CMD ["server"]
+CMD ["./server"]


### PR DESCRIPTION
Optimisation made as part of Exercise 3.7 of the [DevOps with Docker mooc.fi course](https://devopswithdocker.com/part-3/4-optimizing-the-image-size).

The most crucial change was implementing the builder pattern, i.e. separating the build process from running the application in a container. As this project is written in Go, the program can be compiled into a single binary and containerised without any Go tooling. This drastically reduced the image size while keeping the same functionality.

The other change regards security; a non-root user is created after the initial setup to have the container run under a non-root user, which safeguards against vulnerabilities (such as container breakout) by not giving the containerised program access to the host system as root.